### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/Lab1_retention_policies.md
+++ b/Instructions/Labs/Lab1_retention_policies.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Configure Retention Policies'
-    exercise: 'Exercise 1 - Configure Retention Policies'
+  task: Configure Retention Policies
+  exercise: Exercise 1 - Configure Retention Policies
+  title: Exercise 1 skilling tasks
+  description: In this task, you will use PowerShell to create and manage retention policies.
+  duration: 140 minutes
+  level: 200
+  islab: true
 ---
 
 ## WWL Tenants - Terms of use

--- a/Instructions/Labs/Lab2_retention_labels.md
+++ b/Instructions/Labs/Lab2_retention_labels.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Create retention labels'
-    exercise: 'Exercise 2 - Create retention labels'
+  task: Create retention labels
+  exercise: Exercise 2 - Create retention labels
+  title: Exercise 2 skilling tasks
+  description: In this task, you will create retention labels that can be assigned to documents and emails.
+  duration: 126 minutes
+  level: 200
+  islab: true
 ---
 
 ## WWL Tenants - Terms of use

--- a/Instructions/Labs/Lab3_eDiscovery_Premium.md
+++ b/Instructions/Labs/Lab3_eDiscovery_Premium.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    task: 'Case investigation with eDiscovery'
-    exercise: 'Exercise 3 - Case investigation with eDiscovery'
+  task: Case investigation with eDiscovery
+  exercise: Exercise 3 - Case investigation with eDiscovery
+  title: Exercise 3 skilling tasks
+  description: After your case is created, it will take you directly to your new case.
+  duration: 5 minutes
+  level: 100
+  islab: true
 ---
 
 ## WWL Tenants - Terms of use

--- a/Instructions/Labs/Lab4_Communication_Compliance.md
+++ b/Instructions/Labs/Lab4_Communication_Compliance.md
@@ -1,8 +1,14 @@
 ---
 lab:
-    task: 'Configure Communication Compliance'
-    exercise: 'Exercise 4 - Configure Communication Compliance'
+  task: Configure Communication Compliance
+  exercise: Exercise 4 - Configure Communication Compliance
+  title: Exercise 4 skilling tasks
+  description: In this task, you will create a policy using a predefined template to quickly address common compliance scenarios.
+  duration: 84 minutes
+  level: 200
+  islab: true
 ---
+
 ## WWL Tenants - Terms of use
 
 If you are being provided with a tenant as a part of an instructor-led training delivery, please note that the tenant is made available for the purpose of supporting the hands-on labs in the instructor-led training.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/Lab1_retention_policies.md` (title,description,duration,level,islab)
- `Instructions/Labs/Lab2_retention_labels.md` (title,description,duration,level,islab)
- `Instructions/Labs/Lab3_eDiscovery_Premium.md` (title,description,duration,level,islab)
- `Instructions/Labs/Lab4_Communication_Compliance.md` (title,description,duration,level,islab)
